### PR TITLE
Boms-Away Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ for re-use in future designs.
 
 ## Requirements
 
-* python 2.7
+* python 3.6
 * sqlalchemy
 * wxPython (pip install should work on most platforms, otherwise, see [wxPython.org](http://wxpython.org/download.php)
 
@@ -68,11 +68,11 @@ All changes can be saved back to KiCad Schematics
 ### This tool is opinionated!
 
 The tool has to store its information somewhere, so it uses kicad's
-custom component fields. Currently, the fields SPN, MPN, SPR, and MFR
-are reserved for use. If these fields do not exist, they will be
-automatically added to each component as it is accessed. The tool does
-not attempt to do any import or translation of other existing fields
-(field remapping could be added in a future update).
+custom component fields. Currently, the fields SPN, MPN, SPR, MFR, SPN,
+SPURL and DESC are reserved for use. If these fields do not exist, they
+will be automatically added to each component as it is accessed.  The
+tool does not attempt to do any import or translation of other existing
+fields (field remapping could be added in a future update).
 
 ### Schematic saves are not automatic!
 
@@ -80,6 +80,12 @@ If you would like data propegated back to your kicad schematic, please
 select `Save Schematic` from the menu.
 
 ## Changes
+
+### 12/29/19
+* Allow the schematic file to be passed on the command line
+* Added description field and allow SPURL to also be edited
+* Added ability to ignore fidicials, holes, test points, etc.
+* Added ability to ignore do-not-fit (DNF) and variants in value
 
 ### 8/12/16
 
@@ -104,6 +110,7 @@ select `Save Schematic` from the menu.
 * Add Unit tests
 * User Guide
 * Clean up user screens
+* Set default save directory to schematic directory
 
 ## Planned Features
 
@@ -119,6 +126,10 @@ Enable part price lookups and stock amount checking
 ### Bom Price Breakdown View (after octopart)
 
 View overall prices / quantity ordered
+
+### Digikey integration
+
+Same as Octopart
 
 
 ## Feature wishlist

--- a/boms_away/export_plugins/csv_comma.py
+++ b/boms_away/export_plugins/csv_comma.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import csv
 
 from . import _export_base
@@ -13,7 +14,8 @@ class CsvExport(_export_base.BomsAwayExporter):
             wrt = csv.writer(csvfile)
 
             wrt.writerow(['Refs', 'Value', 'Footprint',
-                          'Quantity', 'MFR', 'MPN', 'SPR', 'SPN'])
+                          'Quantity', 'DESC', 'MFR', 'MPN', 'SPR', 'SPN',
+                          'SPURL'])
 
             for fp in sorted(components):
                 for val in sorted(components[fp]):
@@ -23,8 +25,10 @@ class CsvExport(_export_base.BomsAwayExporter):
                         ctcont.value,
                         ctcont.footprint,
                         len(ctcont),
+                        ctcont.description,
                         ctcont.manufacturer,
                         ctcont.manufacturer_pn,
                         ctcont.supplier,
                         ctcont.supplier_pn,
+                        ctcont.supplier_url,
                     ])

--- a/boms_away/export_plugins/csv_pcbway.py
+++ b/boms_away/export_plugins/csv_pcbway.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import csv
+
+from . import _export_base
+
+class CsvPcbwayExport(_export_base.BomsAwayExporter):
+    extension = 'csv'
+    wildcard = 'PCBWay CSV Files (*.csv)|*.csv'
+
+    def export(self, base_filename, components):
+        file_path = '{}.{}'.format(base_filename, self.extension)
+
+        with open(file_path, 'w') as csvfile:
+            wrt = csv.writer(csvfile)
+
+            wrt.writerow(['Item #', 'Ref Des', 'Qty', 'Manufacturer',
+                          'Mfg Part #', 'Value', 'Description', 'Package',
+                          'Supplier', 'Sup Part #', 'Sup URL'])
+            item = 1
+            for fp in sorted(components):
+                for val in sorted(components[fp]):
+                    ctcont = components[fp][val]
+                    wrt.writerow([
+                        item,
+                        ctcont.refs,
+                        len(ctcont),
+                        ctcont.manufacturer,
+                        ctcont.manufacturer_pn,
+                        ctcont.value,
+                        ctcont.description,
+                        ctcont.footprint,
+                        ctcont.supplier,
+                        ctcont.supplier_pn,
+                        ctcont.supplier_url,
+                    ])
+                    item = item + 1

--- a/boms_away/export_plugins/quoted_tab_csv.py
+++ b/boms_away/export_plugins/quoted_tab_csv.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import csv
 
 from . import _export_base
@@ -13,7 +14,7 @@ class QuotedTabExport(_export_base.BomsAwayExporter):
             wrt = csv.writer(csvfile, dialect='excel-tab')
 
             wrt.writerow(['Refs', 'Value', 'Footprint',
-                          'Quantity', 'MFR', 'MPN', 'SPR', 'SPN'])
+                          'Quantity', 'DESC', 'MFR', 'MPN', 'SPR', 'SPN'])
 
             for fp in sorted(components):
                 for val in sorted(components[fp]):
@@ -24,6 +25,7 @@ class QuotedTabExport(_export_base.BomsAwayExporter):
                         '"{}"'.format(ctcont.value),
                         '"{}"'.format(ctcont.footprint),
                         '"{}"'.format(len(ctcont)),
+                        '"{}"'.format(ctcont.description),
                         '"{}"'.format(ctcont.manufacturer),
                         '"{}"'.format(ctcont.manufacturer_pn),
                         '"{}"'.format(ctcont.supplier),

--- a/boms_away/export_plugins/xlsx_excell.py
+++ b/boms_away/export_plugins/xlsx_excell.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+import xlsxwriter
+
+from . import _export_base
+
+class XlsxExport(_export_base.BomsAwayExporter):
+    extension = 'xlsx'
+    wildcard = 'Excel XLSX Files (*.xlsx)|*.xlsx'
+
+    def export(self, base_filename, components):
+        file_path = '{}.{}'.format(base_filename, self.extension)
+        workbook = xlsxwriter.Workbook(file_path)
+        worksheet = workbook.add_worksheet()
+        worksheet.write_row(0, 0,
+                            ['Refs', 'Value', 'Footprint', 'Quantity', 'DESC',
+                             'MFR', 'MPN', 'SPR', 'SPN', 'SPURL']),
+        row = 1
+        for fp in sorted(components):
+            for val in sorted(components[fp]):
+                ctcont = components[fp][val]
+                worksheet.write_row(row, 0,
+                                    [
+                                        ctcont.refs,
+                                        ctcont.value,
+                                        ctcont.footprint,
+                                        len(ctcont),
+                                        ctcont.description,
+                                        ctcont.manufacturer,
+                                        ctcont.manufacturer_pn,
+                                        ctcont.supplier,
+                                        ctcont.supplier_pn,
+                                        ctcont.supplier_url,
+                                    ])
+                row = row + 1
+        workbook.close()

--- a/boms_away/kicad_helpers.py
+++ b/boms_away/kicad_helpers.py
@@ -1,6 +1,47 @@
+# -*- coding: utf-8 -*-
 from . import sch
-import os
+import os, re
 
+# Do not fit list
+DNF = [
+    "dnf",
+    "dnl",
+    "dnp",
+    "dns",
+    "do not fit",
+    "do not place",
+    "do not load",
+    "do not stuff",
+    "nofit",
+    "nostuff",
+    "noplace",
+    "noload",
+    "not fitted",
+    "not loaded",
+    "not placed",
+    "no stuff",
+    "no load",
+    "no place",
+]
+
+REF_EXCLUDES = [
+    '^TP[0-9]+',
+    '^FID[0-9]+',
+    '^H[0-9]+',
+]
+
+FP_EXCLUDES = [
+    'mount.*hole',
+    'test.*point',
+    'ficidial',
+]
+
+VAL_EXCLUDES = [
+    'mount.*hole',
+    'solder.*bridge',
+    'test.*point',
+    'fidicial',
+]
 
 def sanitized(f):
     """
@@ -67,6 +108,7 @@ class ComponentWrapper(object):
             "SPR",
             "SPN",
             "SPURL",
+            "DESC",
         ]
 
         for f in _fields:
@@ -96,7 +138,7 @@ class ComponentWrapper(object):
             return False
 
         return True
-        
+
     @property
     def typeid(self):
         return '{}|{}'.format(self.value,
@@ -123,6 +165,14 @@ class ComponentWrapper(object):
         return self._get_field_value('footprint')
 
     @property
+    def description(self):
+        return self._get_field_value('DESC')
+
+    @description.setter
+    def description(self, desc):
+        self._set_field_value('DESC', desc)
+
+    @property
     def datasheet(self):
         return self._get_field_value('datasheet')
 
@@ -136,6 +186,28 @@ class ComponentWrapper(object):
         if self._cmp.labels['ref'][0] == '#':
             return True
         return False
+
+    @property
+    def is_dnf(self):
+        """ Returns true if component is do-not-fill """
+        for dnf in DNF:
+            if self._get_field_value('value').lower().find(dnf) >= 0:
+                return True
+        return False
+
+    @property
+    def is_excluded(self):
+        """ Returns True if component should be excluded from BOM """
+        for e in REF_EXCLUDES:
+            if re.search(e, self._cmp.labels['ref'].upper()) != None:
+                return True;
+        for e in FP_EXCLUDES:
+            if re.search(e, self.footprint.lower()) != None:
+                return True
+        for e in VAL_EXCLUDES:
+            if re.search(e, self.value.lower()) != None:
+                return True
+        return False;
 
     @property
     def manufacturer(self):
@@ -259,6 +331,15 @@ class ComponentTypeContainer(object):
             c.datasheet = ds
 
     @property
+    def description(self):
+        return self._components[0].description
+
+    @description.setter
+    def description(self, desc):
+        for c in self._components:
+            c.description = desc
+
+    @property
     def manufacturer(self):
         return self._components[0].manufacturer
 
@@ -323,4 +404,4 @@ def walk_sheets(base_dir, sheets, sch_dict):
         )
 
         walk_sheets(base_dir, schematic.sheets, sch_dict)
-            
+


### PR DESCRIPTION
I have added a number of enhancements to Boms-Away as I attempt to teach myself Python.

* Boms-Away will now accept the schematic file from the command line to better integrate with
  KiCad EESchema.
* The supplier URL and a part description are now supported fields which are useful in BOMs
* Two new export filters, one for something close to what PCBWay wants and the other
  exports Excell XSLT.

I still have a number of features planned.
* Save default to schematic directory
* Sort references in column
* Sort BOM by reference
* Integrate Octopart and Digikey support